### PR TITLE
config file for the network side of the dev environment added

### DIFF
--- a/dev/network/config.tf
+++ b/dev/network/config.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "acs730-final-project-group2"    // Bucket from where to GET Terraform State
+    key    = "dev/network/terraform.tfstate" // Object name in the bucket to GET Terraform State
+    region = "us-east-1"                     // Region where bucket created
+  }
+}


### PR DESCRIPTION
The config file makes it possible to get the terraform state files from the s3 bucket. The s3 bucket serves as a backend for the application to retrieve the terraform state and to store the image that would be loaded on the webserver